### PR TITLE
Move w3c-cg to owners

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -3,6 +3,8 @@
   "owners": [
   { "login":  "w3c",
     "group": [] },
+  { "login":  "w3c-cg",
+    "group": [] },
   { "login":  "act-rules",
     "group": [ "cg/act-r" ] },
   { "login":  "webaudio",
@@ -36,7 +38,6 @@
     "w3cping",
     "gpuweb",
     "json-ld",
-    "qt4cg",
-    "w3c-cg"
+    "qt4cg"
   ]
 }


### PR DESCRIPTION
trustedOwners is for groups that are trusted to assign WG repositories. That's not the case for the groups under w3c-cg...
